### PR TITLE
Update edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mprisctl"
 version = "0.1.1"
 authors = ["Christoph Rüßler <christoph.ruessler@mailbox.org>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 dbus = "0.9.0"


### PR DESCRIPTION
Run `cargo fix --edition` and `cargo fmt`, though this did not result in
any changes.
